### PR TITLE
added SCHEDULEDEVENTS handler

### DIFF
--- a/lib/api/lambda.js
+++ b/lib/api/lambda.js
@@ -90,6 +90,16 @@ Lambda.prototype.s3put = function(path, handler) {
 };
 
 /**
+ * Routes SCHEDULED EVENT requests for a given rule to the handler. Rule names will be the path
+ * @param path {string} the path to register the handler at
+ * @param handler {function} function with signature `function(req, res)` for handling the request
+ */
+Lambda.prototype.scheduledEvent = function(path, handler) {
+  this._addHandler({type: 'route', method: 'SCHEDULEDEVENT', path: path, handler: handler });
+  return this;
+};
+
+/**
  * Mounts specified Lambda-level middleware function. Middleware are functions that intercept
  * the request before or after the handler. Middleware must call `res.next()` to pass control to
  * the next middleware in the chain.
@@ -98,16 +108,6 @@ Lambda.prototype.s3put = function(path, handler) {
  */
 Lambda.prototype.use = function(middleware) {
   this._addHandler({type: 'middleware', handler: middleware});
-  return this;
-};
-
-/**
- * Routes SCHEDULED EVENT requests for a given rule to the handler. Rule names will be the path
- * @param path {string} the path to register the handler at
- * @param handler {function} function with signature `function(req, res)` for handling the request
- */
-Lambda.prototype.scheduledEvent = function(path, handler) {
-  this._addHandler({type: 'route', method: 'SCHEDULEDEVENT', path: path, handler: handler });
   return this;
 };
 

--- a/lib/api/lambda.js
+++ b/lib/api/lambda.js
@@ -101,6 +101,16 @@ Lambda.prototype.use = function(middleware) {
   return this;
 };
 
+/**
+ * Routes SCHEDULED EVENT requests for a given rule to the handler. Rule names will be the path
+ * @param path {string} the path to register the handler at
+ * @param handler {function} function with signature `function(req, res)` for handling the request
+ */
+Lambda.prototype.scheduledEvent = function(path, handler) {
+  this._addHandler({type: 'route', method: 'SCHEDULEDEVENT', path: path, handler: handler });
+  return this;
+};
+
 Lambda.prototype._addHandler = function(handler) {
   if (handler.type == 'route') {
     checkConflictingRoutes(this.handlers, handler);

--- a/lib/internal/lambda-events.js
+++ b/lib/internal/lambda-events.js
@@ -12,16 +12,6 @@ function stageFromLambdaArn(arn) {
   console.error('Unable to parse stage from ARN: ' + arn);
 }
 
-function stageFromLambdaArnForScheduledEvent(arn) {
-  if (arn && arn.indexOf('arn:aws:lambda:') === 0) {
-    var parts = arn.split(':');
-    if (parts.length >= 7) {
-      return parts[6];
-    }
-  }
-  console.error('Unable to parse stage from ARN: ' + arn);
-}
-
 function isStandardEvent(event) {
   return event.stage && event.method && event.path;
 }
@@ -88,7 +78,7 @@ function convertScheduledEvent(app, event, context) {
 
   return {
     method: 'SCHEDULEDEVENT',
-    stage: stageFromLambdaArnForScheduledEvent(context.invokedFunctionArn),
+    stage: stageFromLambdaArn(context.invokedFunctionArn),
     path: '/' + path
   };
 }

--- a/lib/internal/lambda-events.js
+++ b/lib/internal/lambda-events.js
@@ -12,6 +12,16 @@ function stageFromLambdaArn(arn) {
   console.error('Unable to parse stage from ARN: ' + arn);
 }
 
+function stageFromLambdaArnForScheduledEvent(arn) {
+  if (arn && arn.indexOf('arn:aws:lambda:') === 0) {
+    var parts = arn.split(':');
+    if (parts.length >= 7) {
+      return parts[6];
+    }
+  }
+  console.error('Unable to parse stage from ARN: ' + arn);
+}
+
 function isStandardEvent(event) {
   return event.stage && event.method && event.path;
 }
@@ -60,6 +70,29 @@ function convertS3PutEvent(app, event, context) {
   };
 }
 
+function isScheduledEvent(event) {
+  return !!event['detail-type'] &&
+    event['detail-type'] == 'Scheduled Event' &&
+    !!event.source &&
+    event.source == 'aws.events' &&
+    !!event.resources &&
+    event.resources.length == 1;
+}
+
+function convertScheduledEvent(app, event, context) {
+  var resources = event.resources[0];
+  var splits = resources.split(':');
+  var rule = splits[splits.length - 1];
+  var ruleSplits = rule.split('/');
+  var path = ruleSplits[1];
+
+  return {
+    method: 'SCHEDULEDEVENT',
+    stage: stageFromLambdaArnForScheduledEvent(context.invokedFunctionArn),
+    path: '/' + path
+  };
+}
+
 module.exports = {
   /**
    * Takes an input Lambda event and converts it to our standard event format. If the event cannot
@@ -70,6 +103,8 @@ module.exports = {
       return event;
     } else if (isS3PutEvent(event)) {
       return convertS3PutEvent(app, event, context);
+    } else if (isScheduledEvent(event)) {
+      return convertScheduledEvent(app, event, context);
     }
   },
 };

--- a/spec/internal/lambda-events-spec.js
+++ b/spec/internal/lambda-events-spec.js
@@ -122,6 +122,19 @@ var API_GATEWAY_EVENT = {
   query: {}
 };
 
+var SCHEDULED_EVENT = {
+  "account": "123456789012",
+  "region": "us-east-1",
+  "detail": {},
+  "detail-type": "Scheduled Event",
+  "source": "aws.events",
+  "time": "1970-01-01T00:00:00Z",
+  "id": "cdc73f9d-aea9-11e3-9d5a-835b769c0d9c",
+  "resources": [
+    "arn:aws:events:us-east-1:123456789012:rule/my-schedule"
+  ]
+};
+
 var CONTEXT = {
   invokedFunctionArn: 'arn:aws:lambda:us-east-1:12345678:function:hello-world-hello:dev'
 }
@@ -133,6 +146,7 @@ describe('LambdaEvents#standardizeEvent', function() {
     app = new Application('test');
     app.lambda({ name: 'foo' })
        .s3put('/uploads/:name', null)
+       .scheduledEvent('/my-schedule', null)
   });
 
   it('passes through API gateway event', function() {
@@ -159,5 +173,13 @@ describe('LambdaEvents#standardizeEvent', function() {
 
   it('rejects DynamoDB event', function() {
     expect(events.standardizeEvent(app, DYNAMODB_UPDATE, CONTEXT)).toBeUndefined();
+  });
+  
+  it('converts scheduled event', function() {
+    expect(events.standardizeEvent(app, SCHEDULED_EVENT, CONTEXT)).toEqual({
+      method: 'SCHEDULEDEVENT',
+      stage: 'dev',
+      path: '/my-schedule'
+    });
   });
 });


### PR DESCRIPTION
@keithito added support for scheduled events. To add a route do this:

```js
app.lambda({name: 'test-scheduled-event'})
    .scheduledEvent('/somerulename', function(req, res) {
      console.log('scheduled event run!');
      res.done();
    });
```

There's some ugliness in `lambda-events.js` where I added the function below. I didn't want to modify `stageFromLambdaArn` but it was looking for specific lengths that were not the same for the SCHEDULEDEVENT event. Let me know a better way to do this. 

```js
function stageFromLambdaArnForScheduledEvent(arn) {
  if (arn && arn.indexOf('arn:aws:lambda:') === 0) {
    var parts = arn.split(':');
    if (parts.length >= 7) {
      return parts[6];
    }
  }
  console.error('Unable to parse stage from ARN: ' + arn);
}
```

I also didn't add any tests because I wasn't quite sure how. Maybe you can show me tomorrow?