### PR TITLE
Dk apigatewayauthorizerevent

### DIFF
--- a/lib/api/lambda.js
+++ b/lib/api/lambda.js
@@ -100,6 +100,16 @@ Lambda.prototype.scheduledEvent = function(path, handler) {
 };
 
 /**
+ * Routes API GATEWAY AUTHORIZER EVENT requests for a given rule to the handler. Rule names will be the path
+ * @param path {string} the path to register the handler at
+ * @param handler {function} function with signature `function(req, res)` for handling the request
+ */
+Lambda.prototype.apiGatewayAuthorizerEvent = function(path, handler) {
+  this._addHandler({type: 'route', method: 'APIGATEWAYAUTHORIZEREVENT', path: path, handler: handler });
+  return this;
+};
+
+/**
  * Mounts specified Lambda-level middleware function. Middleware are functions that intercept
  * the request before or after the handler. Middleware must call `res.next()` to pass control to
  * the next middleware in the chain.

--- a/lib/api/lambda.js
+++ b/lib/api/lambda.js
@@ -100,7 +100,8 @@ Lambda.prototype.scheduledEvent = function(path, handler) {
 };
 
 /**
- * Routes API GATEWAY AUTHORIZER EVENT requests for a given rule to the handler. Rule names will be the path
+ * Routes API GATEWAY AUTHORIZER EVENT requests for a given rule to the handler. 
+ * Rule names will be the method and path, e.g. '/GET/auth'
  * @param path {string} the path to register the handler at
  * @param handler {function} function with signature `function(req, res)` for handling the request
  */

--- a/lib/api/lambda.js
+++ b/lib/api/lambda.js
@@ -101,6 +101,8 @@ Lambda.prototype.scheduledEvent = function(path, handler) {
 
 /**
  * Routes API GATEWAY AUTHORIZER EVENT requests for a given rule to the handler. 
+ * You must set API Gateway resources manually to use a custom Authorizer
+ * AWS Docs - http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html
  * Rule names will be the method and path, e.g. '/GET/auth'
  * @param path {string} the path to register the handler at
  * @param handler {function} function with signature `function(req, res)` for handling the request

--- a/lib/internal/lambda-events.js
+++ b/lib/internal/lambda-events.js
@@ -83,6 +83,30 @@ function convertScheduledEvent(app, event, context) {
   };
 }
 
+function isAPIGatewayAuthorizerEvent(event) {
+  return !!event.type &&
+    event.type == 'TOKEN' &&
+    !!event.authorizationToken &&
+    !!event.methodArn;
+}
+
+function convertAPIGatewayAuthorizerEvent(app, event, context) {
+  var methodArn = event.methodArn;
+  var splits = methodArn.split(':');
+  var rule = splits[splits.length - 1];
+  var ruleSplits = rule.split('/');
+  var stage = ruleSplits[1];
+  var path = ruleSplits[2] + '/' + ruleSplits[3];
+  
+  return {
+    method: 'APIGATEWAYAUTHORIZEREVENT',
+    stage: stage,
+    path: '/' + path,
+    headers: "{Authorization=" + event.authorizationToken + "}",
+    headerNames: "[Authorization]"
+  };
+}
+
 module.exports = {
   /**
    * Takes an input Lambda event and converts it to our standard event format. If the event cannot
@@ -95,6 +119,8 @@ module.exports = {
       return convertS3PutEvent(app, event, context);
     } else if (isScheduledEvent(event)) {
       return convertScheduledEvent(app, event, context);
+    } else if (isAPIGatewayAuthorizerEvent(event)) {
+      return convertAPIGatewayAuthorizerEvent(app, event, context);
     }
-  },
+  }
 };

--- a/lib/internal/lambda-events.js
+++ b/lib/internal/lambda-events.js
@@ -99,7 +99,7 @@ function convertAPIGatewayAuthorizerEvent(app, event, context) {
   var path = ruleSplits[2];
   for (var i = 3; i < ruleSplits.length; i++) {
     path += '/' + ruleSplits[i];
-  };
+  }
   
   return {
     method: 'APIGATEWAYAUTHORIZEREVENT',

--- a/lib/internal/lambda-events.js
+++ b/lib/internal/lambda-events.js
@@ -96,7 +96,10 @@ function convertAPIGatewayAuthorizerEvent(app, event, context) {
   var rule = splits[splits.length - 1];
   var ruleSplits = rule.split('/');
   var stage = ruleSplits[1];
-  var path = ruleSplits[2] + '/' + ruleSplits[3];
+  var path = ruleSplits[2];
+  for (var i = 3; i < ruleSplits.length; i++) {
+    path += '/' + ruleSplits[i];
+  };
   
   return {
     method: 'APIGATEWAYAUTHORIZEREVENT',

--- a/spec/internal/lambda-events-spec.js
+++ b/spec/internal/lambda-events-spec.js
@@ -135,6 +135,12 @@ var SCHEDULED_EVENT = {
   ]
 };
 
+var API_GATEWAY_AUTHORIZER_EVENT = {
+  "authorizationToken": "Bearer foo",
+  "methodArn": "arn:aws:execute-api:us-east-1:282244745782:1tsgzwz575/dev/GET/auth",
+  "type": "TOKEN"
+};
+
 var CONTEXT = {
   invokedFunctionArn: 'arn:aws:lambda:us-east-1:12345678:function:hello-world-hello:dev'
 }
@@ -147,6 +153,7 @@ describe('LambdaEvents#standardizeEvent', function() {
     app.lambda({ name: 'foo' })
        .s3put('/uploads/:name', null)
        .scheduledEvent('/my-schedule', null)
+       .apiGatewayAuthorizerEvent('/auth', null)
   });
 
   it('passes through API gateway event', function() {
@@ -182,4 +189,15 @@ describe('LambdaEvents#standardizeEvent', function() {
       path: '/my-schedule'
     });
   });
+  
+  it('converts api gateway authorizer event', function() {
+    expect(events.standardizeEvent(app, API_GATEWAY_AUTHORIZER_EVENT, CONTEXT)).toEqual({
+      method: 'APIGATEWAYAUTHORIZEREVENT',
+      stage: 'dev',
+      path: '/GET/auth',
+      headers: '{Authorization=Bearer foo}',
+      headerNames: '[Authorization]'
+    });
+  });
+  
 });


### PR DESCRIPTION
@keithito this adds support for API Gateway Authorizer events. You set routes like this:

```js
lambda.apiGatewayAuthorizerEvent('/POST/tag', function(req, res) {
   if (req.headers.Authorization) {
    var token = req.headers.Authorization;
    // check token
    var policy = {}; // IAM Policy
      res.done(null, policy);
    } else {
      sendError(res);
    }
  } else {
    sendError(res);
  }
});
```